### PR TITLE
Added a pip3 upgrade

### DIFF
--- a/notebooks/Step5_Deployment_Pipeline.ipynb
+++ b/notebooks/Step5_Deployment_Pipeline.ipynb
@@ -133,6 +133,7 @@
     "libglib2.0-0:i386 \\\n",
     "&& rm -rf /var/lib/apt/lists/*\n",
     "\n",
+    "RUN pip3 install --upgrade pip\n",
     "RUN pip3 install -U scikit-learn\n",
     "RUN pip3 install numpy pandas sklearn matplotlib\n",
     "RUN pip3 install scipy\n",


### PR DESCRIPTION
This pip3 upgrade is required, in order to install the correct version of matplotlib for python3.5