### PR TITLE
Update Step5_Deployment_Pipeline.ipynb

### DIFF
--- a/notebooks/Step5_Deployment_Pipeline.ipynb
+++ b/notebooks/Step5_Deployment_Pipeline.ipynb
@@ -133,6 +133,7 @@
     "libglib2.0-0:i386 \\\n",
     "&& rm -rf /var/lib/apt/lists/*\n",
     "\n",
+    "RUN pip3 install --upgrade pip==19.3.1\n",
     "RUN pip3 install -U scikit-learn\n",
     "RUN pip3 install numpy pandas sklearn matplotlib\n",
     "RUN pip3 install scipy\n",


### PR DESCRIPTION
Added `RUN pip3 install --upgrade pip==19.3.1`. 

This will prevent the errors:
```
 => ERROR [ 4/22] RUN pip3 install -U scikit-learn                                                                 0.6s
------
 > [ 4/22] RUN pip3 install -U scikit-learn:
#7 0.576 Traceback (most recent call last):
#7 0.576   File "/usr/local/bin/pip3", line 7, in <module>
#7 0.576     from pip._internal.cli.main import main
#7 0.576   File "/usr/local/lib/python3.5/dist-packages/pip/_internal/cli/main.py", line 57
#7 0.576     sys.stderr.write(f"ERROR: {exc}")
#7 0.576                                    ^
#7 0.576 SyntaxError: invalid syntax
------
executor failed running [/bin/sh -c pip3 install -U scikit-learn]: exit code: 1
```